### PR TITLE
Create feature to render minutes as plain text

### DIFF
--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -10,6 +10,11 @@ class MinutesController < ApplicationController
   # GET /minutes/1
   # GET /minutes/1.json
   def show
+    respond_to do |format|
+      format.html {}
+      format.json {}
+      format.text {render plain: JayFlavoredMarkdownToPlainTextConverter.new(@minute.content).content}
+    end
   end
 
   # GET /minutes/new

--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -371,6 +371,87 @@ class JayRemoveMarkupElements < HTML::Pipeline::TextFilter
   end
 end
 
+#
+# Fill columns with MAX_COLUMN characters in one line
+#
+#   (1) One sheep, two sheep, three sheep, four sheep, five sheep.
+#     (A) Six sheep, seven sheep, eight sheep, nine sheep, ten sheep.
+#
+# is converted to:
+#
+#   (1) One sheep, two sheep, three sheep, four
+#       sheep, five sheep.
+#     (A) Six sheep, seven sheep, eight sheep,
+#         nine sheep, ten sheep.
+#
+class JayFillColumns < HTML::Pipeline::TextFilter
+  MAX_COLUMN = 70
+
+  def call
+    lines = @text.split("\n")
+    @text = lines.map do |line|
+      pos = paragraph_position(line)
+      fill_column(line, MAX_COLUMN, pos, ' ')
+    end.join("\n")
+  end
+
+  private
+
+  def character_not_to_allow_newline_in_word?(c)
+    newline = "\n\r"
+    symbol = "-,.，．"
+    small_kana = "ぁぃぅぇぉゃゅょゎァィゥェォャュョヮ"
+    return !!(c =~ /[a-zA-Z#{newline}#{symbol}#{small_kana}]/)
+  end
+
+  # Get position of beginning of line after second line
+  def paragraph_position(str)
+    # Example1: " No.100-01 :: Minutes of GN meeting"
+    #                         ^
+    # Example2: " (A) This is ...."
+    #                ^
+    if /(\s*[^\s]+(\s+::)?\s)/ =~ str
+      return str_mb_width($1)
+    else
+      return 0
+    end
+  end
+
+  # Get width of a character considering multibyte character
+  def char_mb_width(c)
+    return 0 if c == "\r" || c == "\n" || c.empty?
+    return c.ascii_only? ? 1 : 2
+  end
+
+  # Get width of string considering multibyte character
+  def str_mb_width(str)
+    return str.each_char.map{|c| char_mb_width(c)}.inject(:+)
+  end
+
+  # str       : String, not including newline
+  # max_width : Max width in one line
+  # positon   : Position of beginning of line after second line
+  # padding   : Character used padding
+  def fill_column(str, max_width, position, padding)
+    return str if max_width >= str_mb_width(str)
+
+    i = 0; width = 0
+    begin
+      width += char_mb_width(str[i])
+    end while width <= max_width && i += 1
+
+    i += 1 while character_not_to_allow_newline_in_word?(str[i])
+
+    if str.length > i + 1
+      x = str[0..(i-1)] + "\n"
+      xs = "#{padding * position}" + str[i..(str.length-1)]
+      return x + fill_column(xs, max_width, position, padding)
+    else
+      return str
+    end
+  end
+end
+
 ################################################################
 ## HTML to HTML filters
 
@@ -567,6 +648,7 @@ class JayFlavoredMarkdownToPlainTextConverter
       JayAddLabelToListItems,
       JayAddCrossReference,
       JayRemoveMarkupElements,
+      JayFillColumns,
     ], context.merge(@options)
   end
 end


### PR DESCRIPTION
#2 に関する PR である．
app_root/minutes/:id.text にアクセスすることで，テキスト用に整形された議事録を plain text で出力する．
なお，整形内容は以下の2点である．
+ Markdown の要素である以下の5つを削除
   + emphasis ::      ```_hoge_ or *fuga*```
   + header ::       ```#, ##, and ###...```
   + link ::          ```[title](link)```
   + list ::          ```*, +, -```
   + strikethrough :: ```~hoge~```
+ 1行あたり最大文字幅70で改行

   ここで，文字幅は改行文字を0，ASCII 文字を1，それ以外のマルチバイト文字を2とした．なお，71文字幅目以降であっても改行不可な文字の場合は改行せず，改行可能な文字がくるまで改行しない．改行不可な文字は以下の5つである．
  + 小文字(「ゅ」とか)
  + ハイフン
  + ．
  + ，
  + 英文字

最後に，本 PR で解決できていない今後の課題を以下に示す．
+ 箇条書きのインデントの深さが元ファイル依存であるため，深くてもそのまま
+ 宿題や資料提出者を右揃えにするようになっていない
+ タブ文字が入ると揃わない．タブ幅は環境依存なので対処が難しい
+ 人名で改行してしまう
+ URLのようにあまりに長い英文字が続く箇所で70文字を超えると超過する文字数が長くなりすぎる

上記の課題は，#2 にクリティカルな問題でないため，ひとまず PR する．