### PR TITLE
Display modal for selecting repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,7 @@ gem 'bootstrap-sass', '~> 3.3.4'
 
 # haml
 gem 'haml-rails'
+
+# for extension font
+gem 'font-awesome-sass'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     execjs (2.5.2)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    font-awesome-sass (4.3.2.1)
+      sass (~> 3.2)
     gemoji (2.1.0)
     github-linguist (4.5.5)
       charlock_holmes (~> 0.7.3)
@@ -224,6 +226,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.4)
   byebug
   coffee-rails (~> 4.1.0)
+  font-awesome-sass
   gemoji
   github-linguist
   haml-rails
@@ -249,4 +252,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.3
+   1.10.4

--- a/app/assets/javascripts/minutes.coffee
+++ b/app/assets/javascripts/minutes.coffee
@@ -153,6 +153,28 @@ setupAutoCompleteEmoji = (element) ->
     onKeydown: (e, commands) ->
       return commands.KEY_ENTER if e.ctrlKey && e.keyCode == 74 # CTRL-J
 
+setupAutoCompleteRepository = (element, repos_list) ->
+  $(element).textcomplete [
+      match: /([\-+\w]*)$/
+
+      search: (term, callback) ->
+        callback $.map repos_list, (repos) ->
+          return repos if repos.indexOf(term) >= 0
+          return null
+
+      replace:  (value) ->
+        "#{value}"
+
+      index: 1
+    ],
+    onKeydown: (e, commands) ->
+      return commands.KEY_ENTER if e.ctrlKey && e.keyCode == 74 # CTRL-J
+    zIndex: 10000
+    listPosition: (position) ->
+      this.$el.css(this._applyPlacement(position))
+      this.$el.css('position', 'absolute')
+      return this
+
 setupTabCallback = ->
   $('a[data-toggle="tab"]').on 'shown.bs.tab', (e) ->
     old = $(e.relatedTarget).attr('href') # previous active tab
@@ -188,6 +210,7 @@ ready = ->
     if range = getSelectionLineRange()
       minute = getOriginalMinuteAsJSON(range.fst, range.lst)
       repos_list = getGithubTargetRepositoryName(res)
+      setupAutoCompleteRepository('#repository', repos_list)
       repos_list = getGithubTargetRepository(minute, repos_list)
       repos_list = repos_list.filter((x, i, self) ->
         self.indexOf(x) == i

--- a/app/assets/javascripts/minutes.coffee
+++ b/app/assets/javascripts/minutes.coffee
@@ -167,13 +167,13 @@ getGithubTargetRepositoryName = (res) ->
   repos_list
 
 dipslaySelectionLineRange = (str) ->
-  $('#selected-range').replaceWith("<pre id='#selected-range'>#{str}</pre>")
+  $('#selected-range').append("#{str}")
 
 displayGithubRepository = (repos_list) ->
   str_repos = ""
   for r in repos_list
     str_repos = str_repos + "<li class='list-group-item'><input type='checkbox'>#{r}</input></li>"
-  $('#repositores-list').replaceWith("<ul class='list-group' id='repositores-list'>#{str_repos}</ul>")
+  $('#repositories-list').replaceWith("<ul class='list-group' id='repositories-list'>#{str_repos}</ul>")
 
 ready = ->
   res = $. ajax
@@ -192,21 +192,22 @@ ready = ->
       repos_list = repos_list.filter((x, i, self) ->
         self.indexOf(x) == i
       )
+      repos_list = repos_list.map (r) ->
+        "#{minute.organization}/" + r
       displayGithubRepository(repos_list)
       dipslaySelectionLineRange(chopIndent(minute.body))
       $("#choose-repos-modal").modal("show")
+    else
+      alert "No valid range is specified."
+    event.preventDefault()
 
-    # if range = getSelectionLineRange()
-    #   minute = getOriginalMinuteAsJSON(range.fst, range.lst)
-    #   repos = "#{minute.organization}/" + getGithubTargetRepository(minute)[0]
-    #   issue =
-    #     title: removeTrailer(removeHeader(minute.body.split("\n")[-1..][0]))
-    #     body: chopIndent(minute.body)
-    #     labels: "" # FIXME
-    #     assignee: minute.screen_name # FIXME
-    #   newGithubIssue(repos, issue)
-    # else
-    #   alert "No valid range is specified."
-    # event.preventDefault()
+  $('#submit-button').click ->
+    param = $('#submit-form').serializeArray()
+    issue =
+      title: removeTrailer(removeHeader(param[0].value.split("\n")[-1..][0]))
+      body: param[0].value
+      labels: "" # FIXME
+      # assignee: minute.screen_name # FIXME
+    newGithubIssue(param[1].value, issue)
 
 $(document).ready(ready)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -18,3 +18,5 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 //= require jquery-textcomplete
+@import "font-awesome-sprockets";
+@import "font-awesome";

--- a/app/assets/stylesheets/minutes.scss
+++ b/app/assets/stylesheets/minutes.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the minutes controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.candidate-repository{
+  cursor: pointer
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,6 +61,15 @@ class UsersController < ApplicationController
     end
   end
 
+  # GET
+  def repositories
+    @repos = User.current.repos
+    respond_to do |format|
+      format.html
+      format.json {render json: @repos}
+    end
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_user

--- a/app/views/minutes/_choose_repos_modal.html.haml
+++ b/app/views/minutes/_choose_repos_modal.html.haml
@@ -1,0 +1,19 @@
+#choose-repos-modal.modal.fade
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %button.close{"aria-hidden" => "true", "data-dismiss" => "modal", :type => "button"} ×
+        %h4.modal-title Choose Repository
+      .modal-body
+        %form#choose-repos.modal-body
+          %b Massage:
+          %pre#selected-range
+            :preserve
+              
+                                  %b Repositores
+          %ul#repositores-list.list-group
+            %li.list-group-item
+              %input{:type => "checkbox"}/
+      .modal-footer
+        %button.btn{"aria-hidden" => "true", "data-dismiss" => "modal"} Cancel
+        %button#submit-button.btn.btn-primary{:type => "submit"} OK

--- a/app/views/minutes/_choose_repos_modal.html.haml
+++ b/app/views/minutes/_choose_repos_modal.html.haml
@@ -5,13 +5,16 @@
         %button.close{"aria-hidden" => "true", "data-dismiss" => "modal", :type => "button"} ×
         %h4.modal-title Choose Repository
       .modal-body
-        %form#choose-repos.modal-body
-          %b Massage:
-          %pre#selected-range
-            :preserve
-              
-                                  %b Repositores
-          %ul#repositores-list.list-group
+        %form#submit-form
+          %p
+            %b Message:
+          %p
+            %textarea#selected-range{:name => "message"}
+          %p
+            %b Repositories
+          %p
+            %input#repository{:name => "repository", :type => "text"}/
+          %ul#repositories-list.list-group
             %li.list-group-item
               %input{:type => "checkbox"}/
       .modal-footer

--- a/app/views/minutes/_content.html.haml
+++ b/app/views/minutes/_content.html.haml
@@ -1,4 +1,5 @@
 - require "markdown_converter"
+= render :partial => "minutes/create_issue_modal.html.haml"
 .markdown-body
   = raw ::JayFlavoredMarkdownConverter.new(text).content
   %button.action-item New Issue

--- a/app/views/minutes/_create_issue_modal.html.haml
+++ b/app/views/minutes/_create_issue_modal.html.haml
@@ -1,22 +1,19 @@
-#choose-repos-modal.modal.fade
+#create-issue-modal.modal.fade
   .modal-dialog
     .modal-content
       .modal-header
         %button.close{"aria-hidden" => "true", "data-dismiss" => "modal", :type => "button"} ×
-        %h4.modal-title Choose Repository
+        %h4.modal-title Create issue
       .modal-body
         %form#submit-form
           %p
-            %b Message:
+            %textarea#selected-range{:name => "message", :rows => "7"}
           %p
-            %textarea#selected-range{:name => "message"}
+            %b Target repository
           %p
-            %b Repositories
+            %input#repository{:autocomplete => "off", :name => "repository", :type => "text"}/
           %p
-            %input#repository{:name => "repository", :type => "text"}/
-          %ul#repositories-list.list-group
-            %li.list-group-item
-              %input{:type => "checkbox"}/
+          %p#repositories-list
       .modal-footer
         %button.btn{"aria-hidden" => "true", "data-dismiss" => "modal"} Cancel
         %button#submit-button.btn.btn-primary{:type => "submit"} OK

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,20 @@ Rails.application.routes.draw do
   post "/minutes/preview", to: "minutes#preview"
 
   resources :minutes
-  resources :users
+ # resources :users
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
   root 'welcome#index'
 
+#  match "users/repositories/" => "users#repositories", :via => [:get]
+  resources :users do
+    collection do
+      get 'repositories'
+    end
+  end
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 

--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 if __FILE__ == $0
   ################################################################
   # rbenv support:
@@ -494,6 +495,24 @@ class JayShortenIndent < HTML::Pipeline::TextFilter
   end
 end
 
+class JayAddLink < HTML::Pipeline::TextFilter
+  def call
+    lines = @text.split("\n")
+
+    @text = lines.map do |line|
+      line.gsub(/-->\((.+?)\)/) do |macth|
+        "-->([#{$1}](){: .action-item})"
+      end
+    end
+
+    @text = @text.map do |line|
+      line.gsub(/([A-Z_a-z\d]+\/)?#\d+/) do |match|
+        "[#{match}](){: .action-item}"
+      end
+    end.join("\n")
+  end
+end
+
 ################################################################
 ## HTML to HTML filters
 
@@ -613,7 +632,6 @@ class JayCustomItemBullet
   end
 end
 
-
 #
 # Jay Flavored Markdown to HTML converter
 #
@@ -648,6 +666,7 @@ class JayFlavoredMarkdownConverter
       JayFixIndentDepth,
       JayAddLabelToListItems,
       JayAddCrossReference,
+      JayAddLink,
       JayFlavoredMarkdownFilter,
       JayCustomItemBullet::Filter,
       HTML::Pipeline::AutolinkFilter,


### PR DESCRIPTION
#3 に関する PR である．

以下の機能を実装した．
* MarkdownをHTMLに変換するとき，「-->(××)」 と 「○○/△△」がリンクに変換される．
* description にしたい部分をハイライトし，New Issue ボタンをクリックするとモーダルが表示される．
モーダルでリポジトリ名を入力し OK ボタンをクリックすると対応するリポジトリの New Issue が表示される．

今後以下の機能を実装する．
* Repositoryのテキスト形式の部分にオートコンプリートを導入する．
* チェックボックスの部分をクリックすると，テキスト形式の部分に自動でリポジトリ名が埋め込まれる．