### PR TITLE
Count mb_width of empty string as 0

### DIFF
--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -425,6 +425,7 @@ class JayFillColumns < HTML::Pipeline::TextFilter
 
   # Get width of string considering multibyte character
   def str_mb_width(str)
+    return 0 if str.empty?
     return str.each_char.map{|c| char_mb_width(c)}.inject(:+)
   end
 


### PR DESCRIPTION
空文字列に対し each_char すると1度も iterate しない
iterater が返る．これに対し map を適用すると [] が返り，
さらにこれを inject すると nil が返る．
この nil と数値を比較していたため，エラーが発生していた．
そこで， 空文字列を受けた場合は 0 を返すように
メソッドを変更した．