### PR TITLE
Shorten 4 indent to 2 indent

### DIFF
--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -452,6 +452,25 @@ class JayFillColumns < HTML::Pipeline::TextFilter
   end
 end
 
+#
+# Shorten 4 indent to 2 indent.
+#
+class JayShortenIndent < HTML::Pipeline::TextFilter
+  def call
+    @text = @text.split("\n").map do |line|
+      shorten_indent(line)
+    end.join("\n")
+  end
+
+  private
+
+  def shorten_indent(line)
+    return line unless /\A(\s+)(.*)/ =~ line
+    indent_depth = $1.length / 2
+    return "#{' ' * indent_depth}#{$2}"
+  end
+end
+
 ################################################################
 ## HTML to HTML filters
 
@@ -648,6 +667,7 @@ class JayFlavoredMarkdownToPlainTextConverter
       JayAddLabelToListItems,
       JayAddCrossReference,
       JayRemoveMarkupElements,
+      JayShortenIndent,
       JayFillColumns,
     ], context.merge(@options)
   end


### PR DESCRIPTION
#2 の機能改良に関する PR である．

Markdown の default indent は 4 である．
このため，70文字で改行して text 出力する場合に，
indent level が高いと1行に text が入る量が著しく減少する．
そこで，default の 4 indent から 2 indent に変換する
class を作成した．