### PR TITLE
Fix bug that new issue button does not work

### DIFF
--- a/app/assets/javascripts/minutes.coffee
+++ b/app/assets/javascripts/minutes.coffee
@@ -155,7 +155,7 @@ chopIndent = (lines) ->
 #
 findKeywords = (lines, keywords) ->
   regexp = array_to_regexp(keywords, "g")
-  repos = lines.match(regexp)
+  repos = lines.match(regexp) || []
   keywords = repos.filter((x, i, self) ->
     self.indexOf(x) == i
   )


### PR DESCRIPTION
When keyword (e.g. nomlab/jay...) does not exist, new issue button does not work because filter method in findKeywords can not apply to repo that is null.
So, I modify repos assignment.