### PR TITLE
Change regular expression in paragraph_position to stronger constraint

### DIFF
--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -433,7 +433,7 @@ class JayFillColumns < HTML::Pipeline::TextFilter
     #                         ^
     # Example2: " (A) This is ...."
     #                ^
-    if /(\s*[^\s]+(\s+::)?\s)/ =~ str
+    if /(\A\s*([^\s]+ ::|\(.+\)) +)/ =~ str
       return str_mb_width($1)
     else
       return 0


### PR DESCRIPTION
This PR is bug fix.

In feature to convert markdown to text,
there is function to find paragraph position.
This commit changes regular expression to find
paragraph position to a stronger constraint.

For example, following
```
---------------------------------------
Before)
  Example1)
    No.150-01 :: GN meeting minutes
                ^
  Example2)
    (A) This is ...
       ^
  Example3)
    This is ...
        ^
---------------------------------------
After)
  Not to allow Example3
---------------------------------------
```
Reason that Example3 is bad is following.
1) Not suitable as paragraph position
2) When position of the first space has exceeded max width in 1 line(e.g. 70 characters), 
    fill_column func causes is problem.