### PR TITLE
Add magic link notation to GitHub issue

### DIFF
--- a/app/views/minutes/_content.html.haml
+++ b/app/views/minutes/_content.html.haml
@@ -1,5 +1,5 @@
 - require "markdown_converter"
 = render :partial => "minutes/create_issue_modal.html.haml"
 .markdown-body
-  = raw ::JayFlavoredMarkdownConverter.new(text).content
+  = raw ::JayFlavoredMarkdownConverter.new(text, :organization => organization).content
   %button.action-item New Issue

--- a/app/views/minutes/show.html.haml
+++ b/app/views/minutes/show.html.haml
@@ -1,6 +1,6 @@
 - @minute.tags.each do |tag|
   = tag_label(tag)
-= render partial: 'content', locals: {text: @minute.content}
+= render partial: 'content', locals: {text: @minute.content, organization: @minute.organization}
 = link_to 'Edit', edit_minute_path(@minute)
 |
 = link_to 'Back', minutes_path

--- a/lib/markdown_converter.rb
+++ b/lib/markdown_converter.rb
@@ -506,8 +506,9 @@ class JayAddLink < HTML::Pipeline::TextFilter
     end
 
     @text = @text.map do |line|
-      line.gsub(/([A-Z_a-z\d]+\/)?#\d+/) do |match|
-        "[#{match}](){: .action-item}"
+      line.gsub(%r{(?:([\w.-]+)/)??(?:([\w.-]+)/)?#(\d+)}i) do |match|
+        url = "https://github.com/#{$1 || context[:organization]}/#{$2}/issues/#{$3}"
+        "[#{match}](#{url}){: .action-item-issue}"
       end
     end.join("\n")
   end


### PR DESCRIPTION
Markdown [org/repos/#n] is rendered as a link to https://github.com/org/repos/issues/#n
If org/ is omitted, default value is taken from ApplicationSettings.github.organization.