### PR TITLE
Bind GitHub issues to their original jay action items

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -131,3 +131,7 @@ div {
     list-style: square;
   }
 }
+
+.marked {
+  background-color: #fff44f !important;
+}

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -18,7 +18,7 @@ class MinutesController < ApplicationController
     respond_to do |format|
       format.html {}
       format.json {}
-      format.text {render plain: JayFlavoredMarkdownToPlainTextConverter.new(@minute.content).content}
+      format.text {render plain: JayFlavoredMarkdownToPlainTextConverter.new(@minute.cooked_content).content}
     end
   end
 

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,0 +1,5 @@
+class ActionItem < ActiveRecord::Base
+  def uid
+    "%04d" % self.id
+  end
+end

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -1,8 +1,38 @@
 class Minute < ActiveRecord::Base
   belongs_to :author, :class_name => "User", :foreign_key => :author_id
   has_and_belongs_to_many :tags
+  before_validation :add_unique_action_item_marker
 
   def organization
     ApplicationSettings.github.organization
+  end
+
+  # Replace action-item number into corresponding GitHub issue number.
+  # Example:
+  #   "-->(name !:0001)" becomes "-->(name nomlab/jay/#10)"
+  def cooked_content
+    self.read_attribute(:content).split("\n").map do |line|
+      line.gsub(/-->\((.+?)!:([0-9]{4})\)/) do |macth|
+        assignee, action = $1.strip, $2
+
+        issue = ActionItem.find_by_id(action.to_i).try(:github_issue)
+
+        "-->(#{assignee} #{issue || '!:' + action})"
+      end
+    end.join("\n")
+  end
+
+  # Add action-item number with prefix "!:".
+  # Example:
+  #   "-->(name)" becomes "-->(name !:0001)"
+  def add_unique_action_item_marker
+    self.content = self.content.split("\n").map do |line|
+      line.gsub(/-->\((.+?)(?:!:([0-9]{4}))?\)/) do |macth|
+        assignee, action = $1.strip, $2
+
+        action = ActionItem.create.uid unless action
+        "-->(#{assignee} !:#{action})"
+      end
+    end.join("\n")
   end
 end

--- a/app/views/minutes/show.html.haml
+++ b/app/views/minutes/show.html.haml
@@ -1,6 +1,6 @@
 - @minute.tags.each do |tag|
   = tag_label(tag)
-= render partial: 'content', locals: {text: @minute.content, organization: @minute.organization}
+= render partial: 'content', locals: {text: @minute.cooked_content, organization: @minute.organization}
 = link_to 'Edit', edit_minute_path(@minute)
 |
 = link_to 'Back', minutes_path

--- a/db/migrate/20151128032022_create_action_items.rb
+++ b/db/migrate/20151128032022_create_action_items.rb
@@ -1,0 +1,12 @@
+class CreateActionItems < ActiveRecord::Migration
+  def change
+    create_table :action_items do |t|
+      t.string :summary
+      t.string :uid
+      t.string :github_issue
+
+      t.timestamps null: false
+    end
+    add_index :action_items, :github_issue, unique: true
+  end
+end

--- a/test/fixtures/action_items.yml
+++ b/test/fixtures/action_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  summary: MyString
+  uid: MyString
+  github_issue: MyString
+
+two:
+  summary: MyString
+  uid: MyString
+  github_issue: MyString

--- a/test/models/action_item_test.rb
+++ b/test/models/action_item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ActionItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
1. Action items `-->(name)` in minutes are automatically labeled
   like `-->(name !:0001)` before saving to DB.

2. On clicking labeled action item `-->(name !:0001)`,
   draft page of GitHub issue is automatically set up filled with
   the corresponding description of action item.

3. Created GitHub issue will have a link to the original
   action item in jay.