### PR TITLE
Add tags and screen name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,13 @@ class ApplicationController < ActionController::Base
 
         res = webhook.post(@payload)
 
-        logger.info "  Response: #{res.code} #{res.message}"
+        unless res
+          msg = "Failed to connect to #{webhook.uri}: Connection refused"
+          flash[:error] = msg
+          logger.info ("  " + msg)
+        else
+          logger.info "  Response: #{res.code} #{res.message}"
+        end
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,15 +35,22 @@ class ApplicationController < ActionController::Base
     end
     webhooks = settings.map {|setting| Webhook.new(setting)}
 
-    @payload = nil
+    @document = nil
 
     yield
 
-    if @payload
+    if @document
       webhooks.each do |webhook|
         logger.info "Posting minutes to #{webhook.uri}"
 
-        res = webhook.post(@payload)
+        payload = @document.attributes
+        payload.merge!({"tags"=>[], "name"=>nil})
+        @document.tags.each do |tag|
+          payload["tags"] << tag.name
+        end
+        payload["name"] = @document.author.screen_name
+
+        res = webhook.post(payload)
 
         unless res
           msg = "Failed to connect to #{webhook.uri}: Connection refused"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   prepend_before_filter :login_state_setup
   before_filter :authenticate
+  around_action :webhook_action
 
   private
   def login_state_setup
@@ -26,5 +27,26 @@ class ApplicationController < ActionController::Base
     session[:jumpto] = request.parameters
     redirect_to root_path
     return false
+  end
+
+  def webhook_action
+    settings = ApplicationSettings.webhook.select do |setting|
+      setting["events"].include?(action_name)
+    end
+    webhooks = settings.map {|setting| Webhook.new(setting)}
+
+    @payload = nil
+
+    yield
+
+    if @payload
+      webhooks.each do |webhook|
+        logger.info "Posting minutes to #{webhook.uri}"
+
+        res = webhook.post(@payload)
+
+        logger.info "  Response: #{res.code} #{res.message}"
+      end
+    end
   end
 end

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -45,7 +45,7 @@ class MinutesController < ApplicationController
         format.json { render json: @minute.errors, status: :unprocessable_entity }
       end
     end
-    @payload = @minute
+    @document = @minute
   end
 
   # PATCH/PUT /minutes/1
@@ -61,7 +61,7 @@ class MinutesController < ApplicationController
         format.json { render json: @minute.errors, status: :unprocessable_entity }
       end
     end
-    @payload = @minute
+    @document = @minute
   end
 
   def preview

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -1,6 +1,5 @@
 class MinutesController < ApplicationController
   before_action :set_minute, only: [:show, :edit, :update, :destroy]
-  around_action :webhook_action
 
   # GET /minutes
   # GET /minutes.json
@@ -46,6 +45,7 @@ class MinutesController < ApplicationController
         format.json { render json: @minute.errors, status: :unprocessable_entity }
       end
     end
+    @payload = @minute
   end
 
   # PATCH/PUT /minutes/1
@@ -61,6 +61,7 @@ class MinutesController < ApplicationController
         format.json { render json: @minute.errors, status: :unprocessable_entity }
       end
     end
+    @payload = @minute
   end
 
   def preview
@@ -101,23 +102,6 @@ class MinutesController < ApplicationController
       tag_names.split.map do |tag_name|
         tag = Tag.find_by(name: tag_name)
         tag ? tag : Tag.create(name: tag_name)
-      end
-    end
-
-    def webhook_action
-      settings = ApplicationSettings.webhook.select do |setting|
-        setting["events"].include?(action_name)
-      end
-      webhooks = settings.map {|setting| Webhook.new(setting)}
-
-      yield
-
-      webhooks.each do |webhook|
-        logger.info "Posting minutes to #{webhook.uri}"
-
-        res = webhook.post(@minute)
-
-        logger.info "  Response: #{res.code} #{res.message}"
       end
     end
 end

--- a/lib/webhook.rb
+++ b/lib/webhook.rb
@@ -9,10 +9,15 @@ class Webhook
     @content_type = settings["content-type"]
     @events = settings["events"]
   end
+  attr_reader :uri
 
   def post(content_hash)
     http = Net::HTTP.new(@uri.host, @uri.port)
-    http.request(generate_request(content_hash))
+    begin
+      http.request(generate_request(content_hash))
+    rescue
+      return nil
+    end
   end
 
   private


### PR DESCRIPTION
本PRは，#35 で提示した commit を内包しているため，#35 merge 後に merge してください．

application_settings.yaml で指定した URL にポストするドキュメントのデータに
tags と screen_name を追加した．
具体的には，以下の内容のデータをポストする．
```
{
 "id":106,
 "title":"title",
 "dtstart":"2015-12-01T10:00:00.000Z",
 "dtend":"2015-12-01T10:00:00.000Z",
 "location":"104",
 "content":"content",
 "created_at":"2015-12-02T05:22:49.745Z",
 "updated_at":"2015-12-02T05:22:49.745Z",
 "author_id":1,
 "name":"screen_name",
 "tags":["tag1", "tag2"]
 }
```

また，指定された URL にポストできない場合に警告メッセージをフラッシュで表示するようにした．
