### PR TITLE
Fix outgoing webhook

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,10 +30,10 @@ class ApplicationController < ActionController::Base
   end
 
   def webhook_action
-    settings = ApplicationSettings.webhook.select do |setting|
+    settings = ApplicationSettings.outgoing_webhooks.select do |setting|
       setting["events"].include?(action_name)
     end
-    webhooks = settings.map {|setting| Webhook.new(setting)}
+    webhooks = settings.map {|setting| OutgoingWebhook.new(setting)}
 
     @document = nil
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,14 +50,12 @@ class ApplicationController < ActionController::Base
         end
         payload["name"] = @document.author.screen_name
 
-        res = webhook.post(payload)
-
-        unless res
-          msg = "Failed to connect to #{webhook.uri}: Connection refused"
-          flash[:error] = msg
-          logger.info ("  " + msg)
-        else
+        begin
+          res = webhook.post(payload)
           logger.info "  Response: #{res.code} #{res.message}"
+        rescue => e
+          flash[:error] = e.message
+          logger.info ("  " + e.message)
         end
       end
     end

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -45,7 +45,7 @@ class MinutesController < ApplicationController
         format.json { render json: @minute.errors, status: :unprocessable_entity }
       end
     end
-    @document = @minute
+    @payload = pack_payload(@minute)
   end
 
   # PATCH/PUT /minutes/1
@@ -61,7 +61,7 @@ class MinutesController < ApplicationController
         format.json { render json: @minute.errors, status: :unprocessable_entity }
       end
     end
-    @document = @minute
+    @payload = pack_payload(@minute)
   end
 
   def preview
@@ -106,6 +106,16 @@ class MinutesController < ApplicationController
       tag_names.split.map do |tag_name|
         tag = Tag.find_by(name: tag_name)
         tag ? tag : Tag.create(name: tag_name)
+        end
+    end
+
+    def pack_payload(obj)
+      payload = obj.attributes
+      payload.merge!({"tags"=>[], "name"=>nil})
+      obj.tags.each do |tag|
+        payload["tags"] << tag.name
       end
+      payload["name"] = obj.author.screen_name
+      payload
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,24 @@ module ApplicationHelper
   def tag_label(tag)
     raw %(<span class="label label-primary tag-label"><span class="glyphicon glyphicon-tag"></span> #{tag.name}</span>)
   end
+
+  def bootstrap_class_for(flash_type)
+    { success: "alert-success", error: "alert-danger",
+      alert: "alert-warning", notice: "alert-info" }[flash_type.to_sym] || flash_type.to_s
+  end
+
+  def flash_messages(opts = {})
+    flash.each do |flash_type, message|
+      concat(
+        content_tag(:div, message, class: "alert alert-dismissable #{bootstrap_class_for(flash_type)} fade in") do
+          concat(
+            content_tag(:button, class: "close", data: { dismiss: "alert" }) do
+              concat content_tag(:span, "&times;".html_safe)
+            end
+          )
+          concat message
+        end
+      )
+    end
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -44,12 +44,7 @@
       / flash
       .row
         .col-xs-12
-          - conv = {:notice => :success, :error => :danger}
-          - [:notice, :error].each do |typ|
-            - unless flash[typ].blank?
-              %div{:class => "alert alert-#{conv[typ]}", :role => "alert"}
-                = flash[typ]
-                - flash.discard(typ)
+          - flash_messages
         / flash col
       / flash row
       .row

--- a/config/application_settings_sample.yml
+++ b/config/application_settings_sample.yml
@@ -13,9 +13,9 @@ default: &default
       ## It can be checked by:
       ##   curl -u [your-github-account] https://api.github.com/orgs/:org/teams
       allowed_team_id: xxxxx
-  webhook:
+  outgoing_webhooks:
     - url: http://XXXXX
-      content-type: application/json
+      content_type: application/json
       events:
         - create
         - update

--- a/lib/outgoing_webhook.rb
+++ b/lib/outgoing_webhook.rb
@@ -1,15 +1,14 @@
 require 'net/http'
 require 'uri'
 
-class Webhook
+class OutgoingWebhook
   attr_reader :uri
 
   def initialize(settings)
     @uri = URI.parse(settings["url"])
-    @content_type = settings["content-type"]
+    @content_type = settings["content_type"]
     @events = settings["events"]
   end
-  attr_reader :uri
 
   def post(content_hash)
     http = Net::HTTP.new(@uri.host, @uri.port)

--- a/lib/webhook.rb
+++ b/lib/webhook.rb
@@ -13,11 +13,7 @@ class Webhook
 
   def post(content_hash)
     http = Net::HTTP.new(@uri.host, @uri.port)
-    begin
-      http.request(generate_request(content_hash))
-    rescue
-      return nil
-    end
+    http.request(generate_request(content_hash))
   end
 
   private


### PR DESCRIPTION
本PRは #44 を対処した．
変更した部分は次の5点である．
+ bootstrap の flash を使用
+ post に失敗した際にエラーオブジェクトを返却
+ Webhook クラスを OutgoingWebhook クラスに変更
+ outgoing_webhook_action の機能を最小化
  + post する議事録に付加情報を追加する処理を minute_controllerに移動
+ outgoing_webhook_action を around_action から after_action に変更