### PR TITLE
Add function of creating comment to github issues

### DIFF
--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -93,6 +93,36 @@ class MinutesController < ApplicationController
     @minute = @minute.dup
   end
 
+  # for ajax search
+  def search_by_tag
+    unless tag = Tag.find_by(name: params[:tag_name])
+      render json: nil
+    else
+      render json: tag.minutes, include: {author: {only: :name}}
+    end
+  end
+
+  # POST minutes/comment
+  def comment
+    render nothing: true
+    url = params[:url]
+    comment = params[:comment]
+    body = {"body" => comment}
+
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    req = Net::HTTP::Post.new(uri.path)
+    req['Content-Type'] = "application/json"
+    req['Authorization'] = "token "+session[:access_token]
+    req.body = JSON.generate({"body" => comment})
+
+    res = http.request(req)
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_minute

--- a/app/views/minutes/_content.html.haml
+++ b/app/views/minutes/_content.html.haml
@@ -1,5 +1,6 @@
 - require "markdown_converter"
 = render :partial => "minutes/create_issue_modal.html.haml"
+= render :partial => "minutes/create_comment_modal.html.haml"
 .markdown-body
   = raw ::JayFlavoredMarkdownConverter.new(text, :organization => organization).content
   %button.action-item New Issue

--- a/app/views/minutes/_create_comment_modal.html.haml
+++ b/app/views/minutes/_create_comment_modal.html.haml
@@ -1,0 +1,25 @@
+#create-comment-modal.modal.fade
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %button.close{"aria-hidden" => "true", "data-dismiss" => "modal", :type => "button"} ×
+        %h4.modal-title Create issue
+      .modal-body
+        %form#comment-form
+          %p
+            %b Description
+          %p
+            %textarea#comment-body{:name => "message", :rows => "7"}
+          %p
+            %b Target repository
+          %p
+            %input#repository{:autocomplete => "off", :name => "repository", :type => "text"}/
+          %p
+          %p#repositories-list
+          %p
+            %b Target issue number
+          %p
+            %input#issue{:autocomplete => "off", :name => "issue", :type => "text"}/
+      .modal-footer
+        %button.btn{"aria-hidden" => "true", "data-dismiss" => "modal"} Cancel
+        %button#submit-button.btn.btn-primary{:type => "submit"} OK

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   post "/minutes/preview", to: "minutes#preview"
   get "/minutes/search_by_tag", to: "minutes#search_by_tag"
+  post "/minutes/comment", to: "minutes#comment"
 
   resources :minutes do
     member do


### PR DESCRIPTION
#60 に対するPRである．

showページ下部に"Comment to issues"というボタンを作成した．
このボタンを押下するとmodalが開き，指定したGitHubのissueに対してcommentを作成できる．
issueの指定方法は，issue作成時と同様にリポジトリを選択し，対象のissueの番号を入力する．

commentの1行目にはcommentを作成した議事録へのリンクを付与している．
issue作成時とは異なり，AI番号との関連付けしていない．
