### PR TITLE
Modify create comment modal and behavior after creating

### DIFF
--- a/app/assets/javascripts/minutes.coffee
+++ b/app/assets/javascripts/minutes.coffee
@@ -548,8 +548,6 @@ setupIssueForm = (options) ->
 #
 # options = {
 #   selector: CSS selector of target form like '#create-comment-modal'
-#   repos_candidates: Repository names to be listed in repository menu
-#   repos_all: All repository names in ORGANIZATION
 #   repo: Repository name to comment
 #   target: Issue number to comment
 #   description: Issue description (markdown string)
@@ -557,28 +555,17 @@ setupIssueForm = (options) ->
 #
 setupCommentForm = (options) ->
   id = options.selector
+  $("#{id} #target").text("Create comment to #{options.organization}/#{options.repo}/##{options.target}")
   $("#{id} #comment-body").val(options.description)
-  $("#{id} #repository").val(options.repo)
-  $("#{id} #issue").val(options.target)
-
-  str_repos = ""
-  for r in options.repos_candidates
-    str_repos = str_repos + "<label class='label label-primary candidate-repository'>#{r}</label> "
-  $("#{id} #repositories-list").replaceWith("<p id='repositories-list'><i class='fa fa-lightbulb-o fa-fw'></i>#{str_repos}<p>")
-
-  setupAutoCompleteRepository("#repository", options.repos_all)
-
-  $("#{id} .candidate-repository").on 'click', (event) ->
-    $("#{id} #repository").val(event.target.innerHTML)
 
   $("#{id} #submit-button").off('click').on 'click', ->
     param = $("#{id} #comment-form").serializeArray()
-    if param[1].value
+    if param[0].value
       comment = param[0].value
-      newGithubComment("#{options.organization}/#{param[1].value}","#{param[2].value}", comment)
+      newGithubComment("#{options.organization}/#{options.repo}","#{options.target}", comment)
       $('#create-comment-modal').modal("hide")
     else
-      alert "No repository specified"
+      alert "Please input comment"
   return $("#{id}")
 
 ready = ->
@@ -620,8 +607,6 @@ ready = ->
       form = setupCommentForm
         selector: '#create-comment-modal'
         organization: minute.organization
-        repos_candidates: findKeywords(minute.content, repos_all)
-        repos_all: repos_all
         repo: $(this).attr("href").split('/')[4]
         target: $(this).attr("href").split('/')[6]
         description: "Commented from [minute #{minute.id}](#{url}).\n#{description}"

--- a/app/assets/javascripts/minutes.coffee
+++ b/app/assets/javascripts/minutes.coffee
@@ -211,14 +211,18 @@ newGithubIssue = (repos, issue) ->
 newGithubComment = (repos, target_issue_num, comment) ->
   github = 'https://github.com'
   github_api = 'https://api.github.com'
-  $.ajax
+  res = $.ajax
     async: false
     type: "POST"
     url: "/minutes/comment"
+    dataType: 'json'
     data:
       url: "#{github_api}/repos/#{repos}/issues/#{target_issue_num}/comments"
       comment: comment
-  window.open("#{github}/#{repos}/issues/#{target_issue_num}")
+    success: (res) ->
+      window.open(res.html_url)
+    error: (res) ->
+      alert "Failed to create comment"
 
 # Get User's Github *public* repositories in ORGANIZATION
 # https://developer.github.com/v3/repos/#list-organization-repositories

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -104,7 +104,6 @@ class MinutesController < ApplicationController
 
   # POST minutes/comment
   def comment
-    render nothing: true
     url = params[:url]
     comment = params[:comment]
     body = {"body" => comment}
@@ -121,6 +120,7 @@ class MinutesController < ApplicationController
     req.body = JSON.generate({"body" => comment})
 
     res = http.request(req)
+    render json: res.body, status: res.code
   end
 
   private

--- a/app/views/minutes/_create_comment_modal.html.haml
+++ b/app/views/minutes/_create_comment_modal.html.haml
@@ -3,23 +3,14 @@
     .modal-content
       .modal-header
         %button.close{"aria-hidden" => "true", "data-dismiss" => "modal", :type => "button"} ×
-        %h4.modal-title Create issue
+        %h4.modal-title Create comment
       .modal-body
+        %div#target
         %form#comment-form
           %p
             %b Description
           %p
             %textarea#comment-body{:name => "message", :rows => "7"}
-          %p
-            %b Target repository
-          %p
-            %input#repository{:autocomplete => "off", :name => "repository", :type => "text"}/
-          %p
-          %p#repositories-list
-          %p
-            %b Target issue number
-          %p
-            %input#issue{:autocomplete => "off", :name => "issue", :type => "text"}/
       .modal-footer
         %button.btn{"aria-hidden" => "true", "data-dismiss" => "modal"} Cancel
         %button#submit-button.btn.btn-primary{:type => "submit"} OK


### PR DESCRIPTION
#60 に対するPRである．

行った変更は以下の3つである．
+ コメント作成モーダルのタイトルを修正
+ コメント作成モーダルでリポジトリと issue 番号の指定を変更できなくし，対象のリポジトリと issue 番号を上部に文字列として表示
+ コメント作成後，作成したコメントの URL のページを開くように変更
