### PR TITLE
Fix migration

### DIFF
--- a/db/migrate/20150609083528_create_users.rb
+++ b/db/migrate/20150609083528_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :screen_name

--- a/db/migrate/20150609084447_create_minutes.rb
+++ b/db/migrate/20150609084447_create_minutes.rb
@@ -1,4 +1,4 @@
-class CreateMinutes < ActiveRecord::Migration
+class CreateMinutes < ActiveRecord::Migration[4.2]
   def change
     create_table :minutes do |t|
       t.string :title

--- a/db/migrate/20150610112906_add_provider_to_user.rb
+++ b/db/migrate/20150610112906_add_provider_to_user.rb
@@ -1,4 +1,4 @@
-class AddProviderToUser < ActiveRecord::Migration
+class AddProviderToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :provider, :string
   end

--- a/db/migrate/20150610112958_add_uid_to_user.rb
+++ b/db/migrate/20150610112958_add_uid_to_user.rb
@@ -1,4 +1,4 @@
-class AddUidToUser < ActiveRecord::Migration
+class AddUidToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :uid, :string
   end

--- a/db/migrate/20150624091919_add_avatar_url_to_user.rb
+++ b/db/migrate/20150624091919_add_avatar_url_to_user.rb
@@ -1,4 +1,4 @@
-class AddAvatarUrlToUser < ActiveRecord::Migration
+class AddAvatarUrlToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :avatar_url, :string
   end

--- a/db/migrate/20150715020938_create_tags.rb
+++ b/db/migrate/20150715020938_create_tags.rb
@@ -1,4 +1,4 @@
-class CreateTags < ActiveRecord::Migration
+class CreateTags < ActiveRecord::Migration[4.2]
   def change
     create_table :tags do |t|
       t.string :name

--- a/db/migrate/20150715021046_create_minutes_tags.rb
+++ b/db/migrate/20150715021046_create_minutes_tags.rb
@@ -1,4 +1,4 @@
-class CreateMinutesTags < ActiveRecord::Migration
+class CreateMinutesTags < ActiveRecord::Migration[4.2]
   def change
     create_table :minutes_tags, id: false do |t|
       t.references :minute, index: true, foreign_key: true, null: false

--- a/db/migrate/20151128032022_create_action_items.rb
+++ b/db/migrate/20151128032022_create_action_items.rb
@@ -1,4 +1,4 @@
-class CreateActionItems < ActiveRecord::Migration
+class CreateActionItems < ActiveRecord::Migration[4.2]
   def change
     create_table :action_items do |t|
       t.string :summary


### PR DESCRIPTION
Rails6 より マイグレーションファイルにファイル作成時のバージョン指定が必要となったため，修正を行いました．

参考：https://railsguides.jp/active_record_migrations.html