### PR TITLE
Add support for launching by docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pickle-email-*.html
 config/initializers/secret_token.rb
 config/secrets.yml
 config/application_settings.yml
+config/master.key
 
 ## Environment normalisation:
 /.bundle

--- a/Dockerfile_production
+++ b/Dockerfile_production
@@ -1,0 +1,52 @@
+# Dockerfile for jay
+#   https://github.com/nomlab/jay
+#
+# To build image:
+#   docker build -t jay .
+#
+# To run container:
+#   docker run -t -i --name "jay" -p 12321:12321 jay
+#
+# In jay container:
+#   In config/application_settings.yml,
+#   setup GitHub's organization, client_id, client_secret, and allowed_team_id
+
+
+FROM ruby:3.0.0
+
+ARG UID
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install required packages
+RUN apt-get update -qq \
+    && apt-get install -y locales sudo build-essential git-core vim libsqlite3-dev nodejs\
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale
+RUN locale-gen ja_JP.UTF-8
+ENV LANG ja_JP.UTF-8
+ENV LANGUAGE ja_JP:ja
+ENV LC_TIME C
+ENV TZ Asia/Tokyo
+RUN localedef -f UTF-8 -i ja_JP ja_JP.utf8
+
+# Add jay user
+RUN useradd -ms /bin/bash -u $UID jay
+RUN usermod -aG sudo jay
+RUN sed -i 's/^%sudo.*$/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers
+
+# Copy app files from cwd
+WORKDIR /home/jay
+COPY . /home/jay
+RUN chown -R jay:jay /home/jay
+
+# Switch user to jay
+USER jay
+
+# Install gem
+RUN gem install bundler
+RUN bundle config set path 'vendor/bundle'
+RUN bundle install
+CMD ["./scripts/docker/docker-entrypoint.sh"]

--- a/README.org
+++ b/README.org
@@ -123,6 +123,19 @@
       $ bundle exec rake db:migrate RAILS_ENV=production
       #+END_SRC
 
+** Setup by Docker
+    1) Clone jay from github
+      #+BEGIN_SRC sh
+      $ git clone https://github.com/nomlab/jay.git ~/Programs/jay
+      $ cd ~/Programs/jay
+      #+END_SRC
+    2) Setup application settings
+      1) See above items 3 ~ 6
+    3) Setup jay image
+      #+BEGIN_SRC sh
+      $ ./scripts/setup-docker.sh
+      #+END_SRC
+
 * Launch jay
 ** development
     #+BEGIN_SRC sh
@@ -149,3 +162,13 @@
     # stop
     $ kill $(cat tmp/pids/server.pid)
     #+END_SRC
+
+** launch production by Docker
+    #+BEGIN_SRC sh
+    # start
+    $ ./scripts/launch-docker.sh start
+
+    # stop
+    $ ./scripts/launch-docker.sh stop
+    #+END_SRC
+

--- a/README.org
+++ b/README.org
@@ -133,7 +133,8 @@
       1) See above items 3 ~ 6
     3) Setup jay image
       #+BEGIN_SRC sh
-      $ ./scripts/setup-docker.sh
+      $ ./scripts/setup-docker.sh jay
+      # Replace "jay" with the name of user that runs jay container
       #+END_SRC
 
 * Launch jay

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,34 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket
+
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+main() {
+    cd "$(dirname "$0")"
+    cd ../
+
+    # run rails server
+    export RAILS_ENV="production"
+    export RAILS_SERVE_STATIC_FILES=true
+    bundle exec rails assets:precompile RAILS_ENV="$RAILS_ENV"
+    bundle exec rails s -b 0.0.0.0 -p 3000 -e "$RAILS_ENV" &
+
+    # get pid of rails server
+    pid=$!
+
+    # stop server when receive SIGTERM
+    trap 'signal_handler $pid' SIGTERM
+
+    # wait for daemon stopping
+    wait
+}
+
+signal_handler() {
+    echo "Stopping process pid: $1"
+    kill -2 $1
+}
+
+main

--- a/scripts/docker/docker-setup.sh
+++ b/scripts/docker/docker-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "create master.key"
+EDITOR=':' bundle exec rails credentials:edit
+
+echo "migrate database"
+bundle exec rails db:migrate RAILS_ENV=production

--- a/scripts/launch-docker.sh
+++ b/scripts/launch-docker.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+#This script only works under below conditions
+# 1. Docker is installed
+
+# specify container name
+CONTAINER_NAME=jay
+
+function usage(){
+    cat <<_EOT_
+launch-docker.sh
+
+Usage:
+    $0 Option
+
+Description:
+    start and stop $CONTAINER_NAME on container
+
+Options:
+    start      start $CONTAINER_NAME on container
+    stop       stop $CONTAINER_NAME
+    status     show $CONTAINER_NAME's condition
+    restart    stop and restart container
+    help       show this usage
+    [command]  execute [command] in container
+_EOT_
+}
+
+function main(){
+    if ! user_belongs_dockergroup; then
+        echo "You have to be member of docker group"
+        exit 1
+    fi
+
+    cd "$(dirname "$0")"
+    cd ../
+
+    case "$1" in
+        start)
+            start
+            ;;
+        stop)
+            stop
+            ;;
+        status)
+            status
+            ;;
+        restart)
+            restart
+            ;;
+        help)
+            usage
+            ;;
+        *)
+            start_with_command "$1"
+            ;;
+    esac
+    return 0
+}
+
+function user_belongs_dockergroup(){
+    if [ $(groups | grep -c -e docker -e root) = 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+function start(){
+    if container_is_running $CONTAINER_NAME; then
+        echo "$CONTAINER_NAME has already runnning"
+    else
+        echo -n "try to start $CONTAINER_NAME..."
+        docker run -d --name $CONTAINER_NAME -p 3000:3000 \
+            -v $PWD/db:/home/jay/db \
+            -v $PWD/config:/home/jay/config \
+            --restart=always \
+            $CONTAINER_NAME > /dev/null && \
+            echo "done." || \
+            exit 1
+    fi
+}
+
+function start_with_command(){
+    if container_is_running $CONTAINER_NAME; then
+        echo "$CONTAINER_NAME has already runnning"
+    else
+        docker run -it --name $CONTAINER_NAME -p 3000:3000 \
+            -v $PWD/db:/home/jay/db \
+            -v $PWD/config:/home/jay/config \
+            $CONTAINER_NAME  "$1"
+    fi
+}
+
+function stop(){
+    if container_is_running $CONTAINER_NAME; then
+        echo -n "try to stop $CONTAINER_NAME..."
+        docker stop $CONTAINER_NAME > /dev/null 2>&1
+        docker rm $CONTAINER_NAME > /dev/null && \
+            echo "done." || \
+            exit 1
+    else
+        echo "$CONTAINER_NAME is not running"
+    fi
+}
+
+function status(){
+    if container_is_running $CONTAINER_NAME; then
+        echo "running"
+    else
+        echo "stop"
+    fi
+}
+
+function restart(){
+    if container_is_running $CONTAINER_NAME; then
+        stop
+        start
+    else
+        echo "$CONTAINER_NAME is not runnning"
+        start
+    fi
+}
+
+function container_is_running(){
+    if [ $(docker ps -a --format "table {{.Names}}" |grep -cx "$1") = 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+main "$@"

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -1,14 +1,48 @@
 #!/bin/bash
 
-cd $(dirname $0)
-cd ../
+# This scripts is for setting up jay image
+# * Create jay image
+# * Create master.key
+# * Migrate database for production
 
-echo "Create jay image"
-UID_SH=$(id -u)
-docker build -t jay -f ./Dockerfile_production --build-arg UID=$UID_SH .
+function main() {
+    cd $(dirname $0)
+    cd ../
 
-echo "Setup secret key and database"
-./scripts/launch-docker.sh ./scripts/docker/docker-setup.sh
-./scripts/launch-docker.sh stop
+    if [ "$1" = "" ]; then
+        usage
+        exit 1
+    fi
 
-echo "Done."
+    if ! (user_exists $1); then
+        echo "Specified user does not exist"
+        exit 1
+    fi
+
+    echo "Create jay image"
+    UID_SH=$(id -u $1)
+    docker build -t jay -f ./Dockerfile_production --build-arg UID=$UID_SH .
+
+    echo "Setup secret key and database"
+    ./scripts/launch-docker.sh ./scripts/docker/docker-setup.sh
+    ./scripts/launch-docker.sh stop
+
+    echo "Done."
+}
+
+function usage() {
+    cat <<_EOT_
+setup-docker.sh <UserName>
+<UserName> is the name of user that runs jay container.
+_EOT_
+}
+
+function user_exists() {
+    if id -u $1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+main $1

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd $(dirname $0)
+cd ../
+
+echo "Create jay image"
+UID_SH=$(id -u)
+docker build -t jay -f ./Dockerfile_production --build-arg UID=$UID_SH .
+
+echo "Setup secret key and database"
+./scripts/launch-docker.sh ./scripts/docker/docker-setup.sh
+./scripts/launch-docker.sh stop
+
+echo "Done."


### PR DESCRIPTION
#105 に対する PR

## やったこと
+ Docker を用いて jay のセットアップ，および起動が行えるようにした．

## 工夫
+ jay イメージの起動時に "--restart=always" オプションをつけることで，docker デーモンの再起動時や OS の起動時に自動で jay イメージが起動するようにした．
+ config ディレクトリをコンテナにマウントすることで，ホスト側から jay の設定を変更できるようにした．
+ db ディレクトリをコンテナにマウントすることで，コンテナ内のデータをホストに保存できるようにした．
+ jay イメージの jay ユーザをイメージ作成者と同じ UID にすることで，上記のマウントの際にパーミッションの齟齬が発生しないようにした．

## 変更点
+ ファイルの追加
  + Dockerfile_production
    + production サーバ用の Dockerfile
  + scripts/setup-docker.sh
    + jay イメージの作成，secret key の作成，データベースのマイグレーションを行うシェルスクリプト
  + scripts/launch-docker.sh
    + jay イメージの起動，停止，再起動を行うシェルスクリプト
  + scripts/docker/docker-entrypoint.sh
    + jay イメージの ENTRYPOINT となるシェルスクリプト
  + scripts/docker/docker-setup.sh
    + Docker 内で secret key，およびデータベースのマイグレーションを行うシェルスクリプト
  + config/storage.yml
    + rails 6.0 の起動に必要なファイル
+ ファイルの修正
  + README.org
   + Docker を用いたセットアップ，および起動について追記
  + .gitignore
    + master.key がコミットされないように変更
