### PR TITLE
Add css property for unordered list

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -48,6 +48,11 @@ li.bullet-list-item {
   text-indent: -2.4em;
 }
 
+ul > li {
+  margin-left: 0px;
+  text-indent: 0em;
+}
+
 .bullet-list-marker {
   font-family: monospace !important;
   font-weight: normal;


### PR DESCRIPTION
issue #10 ，#106 に対してのPR

**概要**
項番付きリストに入れ子で項番なしリストを用いると後続の文字がビュレットに重なる問題があった．
この問題の発生原因としては，HTML，CSS の項番付きリストを非表示にし，jay のライブラリ（markdown_converter.rb）で項番付きリストの項番のインクリメント，生成を行っていた．
これによって，項番付きリストの左にマージンが生じていたため，CSS で list-item を左にずらしていた．
これが項番なしリストにも影響し，今回の問題が発生していた．

**解決法**
項番なしリストの子のリスト（ul > li）に対してマージンを取らないようにする．