### PR TITLE
Fix calling option of organization

### DIFF
--- a/app/assets/javascripts/minutes.coffee
+++ b/app/assets/javascripts/minutes.coffee
@@ -539,7 +539,7 @@ setupIssueForm = (options) ->
       issue =
         title: param[0].value
         body: param[1].value
-        projects: "#{organization}/1"
+        projects: "#{options.organization}/1"
         # labels: "" # FIXME
         # assignee: minute.screen_name # FIXME
       newGithubIssue("#{options.organization}/#{param[2].value}", issue)


### PR DESCRIPTION
app/assets/javascripts/minutes.coffee において，
"#{options.organization}/1" と書くべき箇所を
"#{organization}/1" と書いていたため，修正した．